### PR TITLE
Extend EventEmitter rather than implement it

### DIFF
--- a/lib/event-emitter.d.ts
+++ b/lib/event-emitter.d.ts
@@ -1,16 +1,6 @@
 declare namespace Electron {
 
-	class EventEmitter implements NodeJS.EventEmitter {
-		addListener(event: string, listener: Function): this;
-		on(event: string, listener: Function): this;
-		once(event: string, listener: Function): this;
-		removeListener(event: string, listener: Function): this;
-		removeAllListeners(event?: string): this;
-		setMaxListeners(n: number): this;
-		getMaxListeners(): number;
-		listeners(event: string): Function[];
-		emit(event: string, ...args: any[]): boolean;
-		listenerCount(type: string): number;
+	class EventEmitter extends NodeJS.EventEmitter {
 	}
 
 	interface Event {


### PR DESCRIPTION
See DefinitelyTyped#10977 

Since Node's EventEmitter is a class with implementation, the previous version of this is fragile when the base class adds new members, an implements definition needs changes.    By using `extends` rather than `implments`, inheritance of new methods is automatic.
